### PR TITLE
Move Query Data to IndexedDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@welldone-software/why-did-you-render": "^3.3.5",
     "brace": "^0.11.1",
     "cross-fetch": "^3.0.4",
+    "dexie": "^2.0.4",
     "fast-deep-equal": "^2.0.1",
     "fp-ts": "^2.0.3",
     "guid-typescript": "^1.0.9",

--- a/src/QueryViz.tsx
+++ b/src/QueryViz.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 
-import { queryData, QueryVizData, queryDataChanged } from './query';
+import { queryKey, getDataById, QueryMeta, QueryVizData, queryDataChanged } from './query';
 import { exportViz, deleteViz, hasReportMeta, ReportCode, VizState, Guid, AppState, setVizSpec, } from './store';
 import Vega, { VisualizationSpec, EmbedOptions } from './vega';
 import QueryBuilder from './QueryBuilder';
@@ -21,13 +21,14 @@ type QueryVizProps = {
     setSpec: typeof setVizSpec, 
     deleteViz: typeof deleteViz,
     exportViz: typeof exportViz,
-    data: QueryVizData | undefined
+    data_indices: number[] | null
 };
 
 type QueryVizState = {
     flipped: boolean;
     menu: boolean;
     specString: string;
+    data: QueryVizData | null;
 }
 
 const emSize = Number(getComputedStyle(document.body,null)!.fontSize!.replace(/[^\d]/g, ''));
@@ -69,22 +70,47 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
         super(props);
 
         this.state = { 
-            flipped: !props.data, 
+            flipped: false,
             menu: false,
-            specString: JSON.stringify(props.state.spec, null, 2) 
+            specString: JSON.stringify(props.state.spec, null, 2),
+            data: null,
         };
     }
 
     shouldComponentUpdate(nextProps: QueryVizProps, nextState: QueryVizState) {
-        if(!equal(nextState, this.state) || !equal(nextProps.state, this.props.state)) {
+        if(!equal(nextProps, this.props)) {
             return true;
-        } else if(typeof nextProps.data !== typeof this.props.data) {
+        } else if(this.state.data === null && !equal(nextState, this.state)) {
             return true;
-        } else if(nextProps.data !== undefined && this.props.data !== undefined) {
-            return queryDataChanged(nextProps.data, this.props.data);
+        } else if(nextState.data !== null && this.state.data !== null) {
+            return queryDataChanged(nextState.data, this.state.data);
         }
 
-        return false;
+        return !equal({ ...nextState, data: null }, { ...this.state, data: null });
+    }
+
+    _updateData() {
+        if(this.props.data_indices !== null) {
+            getDataById(this.props.data_indices)
+                .then((data) => this.setState({
+                    data: {
+                        name: 'data',
+                        values: data.filter((datum) => datum !== undefined)
+                        .reduce((result, datum) => result.concat(datum!.values), [] as any[])
+                    }
+                }))
+                .catch((err) => console.error(err));
+        }
+    }
+
+    componentDidMount() {
+        this._updateData();
+    }
+
+    componentDidUpdate(prevProps: QueryVizProps) {
+        if(!equal(this.props.data_indices, prevProps.data_indices)) {
+            this._updateData();
+        }
     }
 
     flip() {
@@ -100,7 +126,9 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
     }
 
     render() {
-        const { state, data, setSpec, exportViz, deleteViz } = this.props;
+        console.log(this.props);
+        const { state, setSpec, exportViz, deleteViz } = this.props;
+        const { data } = this.state;
         const spec = { ...state.spec, data } as VisualizationSpec;
         console.log(spec);
 
@@ -149,11 +177,21 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
     }
 }
 
+function getDataIndices(state: AppState, code: ReportCode | null, query: QueryMeta | null): number[] | null {
+    if(code && hasReportMeta(state, code) && query) {
+        const indices = state.reports.getIn([code, 'queries', queryKey(query)]);
+        if(indices) {
+            return indices.valueSeq().toArray();
+        }
+    }
+    return null;
+}
+
 const mapState = (state: AppState, { code, guid }: { code: ReportCode | null, guid: Guid }) => {
     const vizState = state.visualizations.get(guid)!;
     return {
         state: vizState,
-        data: (code && hasReportMeta(state, code) && vizState.query) ? queryData(vizState.query, code, state) : undefined,
+        data_indices: getDataIndices(state, code, vizState.query),
     };
 };
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -75,8 +75,8 @@ async function loadFightData(report: ReportCode, fight: number | number[], query
     }).toArray();
 }
 
-export async function getDataById(indices: number[]): Promise<(QueryVizData | undefined)[]> {
-    return Promise.all(indices.map((index) => db.records.get(index).then((datum) => datum ? datum.data : datum)));
+export async function getDataById(indices: number[]): Promise<(QueryDataRecord | undefined)[]> {
+    return Promise.all(indices.map((index) => db.records.get(index)));
 }
 
 export async function storeData(report: ReportCode, fight: number, query: QueryMeta, data: QueryVizData): Promise<number> {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,30 @@
 import { AppState, ReportCode, lookupActorName } from './store';
 import { Newtype, prism } from 'newtype-ts';
 import { toNullable } from 'fp-ts/lib/Option';
+import Dexie from 'dexie';
+
+interface QueryDataRecord {
+    id?: number,
+    report: string,
+    fight: number,
+    queryKey: string,
+    data: QueryVizData,
+}
+
+class QueryDataDB extends Dexie {
+    records: Dexie.Table<QueryDataRecord, number>;
+
+    constructor() {
+        super("QueryData");
+        this.version(1).stores({
+            records: '++id, report, fight, queryKey',
+        });
+
+        this.records = this.table('records');
+    }
+}
+
+const db = new QueryDataDB();
 
 export enum QueryType { Event = "event", Table = "table" }
 export interface EventQuery {
@@ -45,6 +69,24 @@ export function queryKey(query: QueryMeta): QueryId {
     return toNullable(QueryId.getOption(JSON.stringify(query)))!;
 }
 
+async function loadFightData(report: ReportCode, fight: number | number[], query: QueryMeta): Promise<QueryDataRecord[]> {
+    return db.records.where({
+        report: report.toString(), fight, meta: queryKey(query).toString()
+    }).toArray();
+}
+
+export async function getDataById(indices: number[]): Promise<(QueryVizData | undefined)[]> {
+    return Promise.all(indices.map((index) => db.records.get(index).then((datum) => datum ? datum.data : datum)));
+}
+
+export async function storeData(report: ReportCode, fight: number, query: QueryMeta, data: QueryVizData): Promise<number> {
+    return db.records.put({
+        report: report.toString(),
+        queryKey: queryKey(query).toString(),
+        fight, data,
+    });
+}
+
 export function shouldUpdate(query: QueryMeta, report: ReportCode, state: AppState): boolean {
     const report_data = state.reports.get(report);
     if(report_data === undefined) {
@@ -60,19 +102,25 @@ export function shouldUpdate(query: QueryMeta, report: ReportCode, state: AppSta
     return false;
 }
 
-export function missingFights(query: QueryMeta, report: ReportCode, state: AppState): number[] {
+function relevantFights(query: QueryMeta, report: ReportCode, state: AppState): number[] {
     const report_data = state.reports.get(report)!;
-    const query_data = report_data.queries.get(queryKey(query));
     const relevant_fights = report_data.fights
         .filter(({boss}) => boss > 0) // only include boss fights, no trash
         .filter(({boss}) => query.bossid === null || String(boss) === query.bossid)
         // TODO: this probably doesn't work as intended
-        .filter(({id}) => !state.requests.queries.contains([queryKey(query), report, id]));
+        .filter(({id}) => !state.requests.queries.contains([queryKey(query), report, id]))
+        .map(({id}) => id);
+    return relevant_fights;
+}
+
+export function missingFights(query: QueryMeta, report: ReportCode, state: AppState): number[] {
+    const report_data = state.reports.get(report)!;
+    const query_data = report_data.queries.get(queryKey(query));
+    const relevant_fights = relevantFights(query, report, state);
     if (query_data === undefined) {
-        return relevant_fights.map(({id}) => id);
+        return relevant_fights;
     } else {
-        return relevant_fights.filter(({id}) => !query_data.has(id.toString()))
-            .map(({id}) => id);
+        return relevant_fights.filter((id) => !query_data.has(id.toString()));
     }
 }
 
@@ -141,18 +189,18 @@ export type QueryVizData = {
     name: string,
     values: any[],
 };
-export function queryData(query: QueryMeta, code: ReportCode | null, state: AppState): QueryVizData {
-    if(code === null) {
-        return { name: 'data', values: state.reports.valueSeq()
-            .map(({code}) => queryData(query, code, state))
-            .reduce((full, {values: next}) => full.concat(next), [] as object[])};
+export async function queryData(query: QueryMeta, code: ReportCode, state: AppState): Promise<QueryVizData | null> {
+    const query_data = await loadFightData(code, relevantFights(query, code, state), query);
+    if(query_data.length === 0) {
+        return Promise.resolve(null);
     } else {
-        const query_data = state.reports.get(code)!.queries.get(queryKey(query));
-        if(query_data === undefined) {
-            return { name: 'data', values: [] }
-        } else {
-            return { name: 'data', values: query_data.valueSeq().reduce((full, {values: next}) => full.concat(next), [] as object[])};
-        }
+        const values = query_data
+            .map(({data}) => data)
+            .reduce((full, {values: next}) => full.concat(next), [] as object[]);
+        return Promise.resolve({ 
+            name: 'data',
+            values,
+        });
     }
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,7 +4,6 @@ import { createLogger } from 'redux-logger';
 import { persistStore, persistReducer, createMigrate } from 'redux-persist';
 import storage from 'localforage';
 import immutableTransform from 'redux-persist-transform-immutable';
-import decompressTransform from './decompress';
 
 import { Newtype, prism } from 'newtype-ts';
 import { toNullable } from 'fp-ts/lib/Option';
@@ -12,7 +11,7 @@ import { Guid as GuidCreator } from 'guid-typescript';
 import { Map, OrderedMap, Set, List, Seq } from 'immutable';
 
 import { load_meta, load_query_data } from './request';
-import { QueryVizData, QueryId, QueryMeta, queryKey, queryFormatData, createQueryMeta, shouldUpdate as shouldUpdateQuery, missingFights as queryFightsMissing, isQueryMeta } from './query';
+import { QueryId, QueryMeta, queryKey, queryFormatData, createQueryMeta, shouldUpdate as shouldUpdateQuery, missingFights as queryFightsMissing, isQueryMeta, storeData } from './query';
 
 export interface ApiKey extends Newtype<{readonly ApiKey: unique symbol}, string> {}
 
@@ -40,7 +39,7 @@ export function isVizState(val: any): val is VizState {
 
 export type PendingUpdate = {
     key: [ReportCode, string, QueryId, number],
-    data: QueryVizData,
+    index: number,
 };
 
 export type AppState = {
@@ -78,7 +77,7 @@ export type ReportState = {
     fights: FightMeta[],
     friendlies: ActorMeta[],
     enemies: ActorMeta[],
-    queries: Map<QueryId, Map<string, QueryVizData>>
+    queries: Map<QueryId, Map<string, number>>
 };
 
 export function lookupActor(report: ReportState, id: number): ActorMeta | undefined {
@@ -109,7 +108,7 @@ function emptyReportState(code: ReportCode): ReportState {
     };
 }
 
-const CURRENT_VERSION = 1;
+const CURRENT_VERSION = 2;
 
 const initialState: AppState = {
     version: CURRENT_VERSION,
@@ -240,7 +239,7 @@ interface RetrievedUpdateQueryAction {
     code: ReportCode,
     fight: number,
     query: QueryMeta,
-    body: object,
+    index: number,
 }
 
 export const ERROR_UPDATE_QUERY = Symbol("ERROR_UPDATE_QUERY");
@@ -277,9 +276,13 @@ export function updateQueries(code: ReportCode): ThunkAction<void, AppState, und
 
             Promise.all(fights.map(fight => {
                 return load_query_data(app_state.api_key!, code, report.fights.find(({ id }) => id === fight)!, query!)
-                    .then(body => dispatch({
+                    .then(body => {
+                        const data = queryFormatData(code, fight, query!, body, app_state);
+                        return storeData(code, fight, query!, data);
+                    })
+                    .then(index => dispatch({
                         type: RETRIEVED_UPDATE_QUERY,
-                        code, fight, query, body,
+                        code, fight, query, index,
                     }),
                         body => {
                             console.error(body);
@@ -530,14 +533,14 @@ function rootReducer(state = initialState, action: DashboardAction): AppState {
                 },
                 pending_updates: state.pending_updates.push({ 
                     key: [action.code, 'queries', queryKey(action.query), action.fight], 
-                    data: queryFormatData(action.code, action.fight, action.query, action.body, state)}
-                ),
+                    index: action.index,
+                }),
             };
         case MERGE_UPDATES:
            const next_state = {
                 ...state,
                 pending_updates: List(),
-                reports: state.pending_updates.reduce((reports, { key, data }) => reports.setIn(key, data), state.reports),
+                reports: state.pending_updates.reduce((reports, { key, index }) => reports.setIn(key, index), state.reports),
             };
             return purgeQueries(next_state);
         case DELETE_VIZ:
@@ -610,6 +613,17 @@ const migrations = {
                 }
             }),
         };
+    },
+    1: (state: any) => {
+        return {
+            ...state,
+            reports: state.reports.map((report: any) => {
+                return {
+                    ...report,
+                    queries: Map(),
+                };
+            })
+        };
     }
 };
 
@@ -619,7 +633,7 @@ export default function buildStore() {
         version: CURRENT_VERSION,
         storage,
         blacklist: ['requests', 'errors', 'pending_updates', 'exporting', 'importing'],
-        transforms: [immutableTransform(), decompressTransform()],
+        transforms: [immutableTransform()],
         migrate: createMigrate(migrations, {debug: true}),
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3524,6 +3524,11 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+dexie@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-2.0.4.tgz#6027a5e05879424e8f9979d8c14e7420f27e3a11"
+  integrity sha512-aQ/s1U2wHxwBKRrt2Z/mwFNHMQWhESerFsMYzE+5P5OsIe5o1kgpFMWkzKTtkvkyyEni6mWr/T4HUJuY9xIHLA==
+
 diff-match-patch@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"


### PR DESCRIPTION
This avoids the bottleneck of localforaging the entire dataset every single update. Should dramatically improve performance.

:crossed_fingers: i don't break everything