### PR TITLE
Queries now share data across bosses

### DIFF
--- a/src/QueryViz.tsx
+++ b/src/QueryViz.tsx
@@ -81,7 +81,7 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
     shouldComponentUpdate(nextProps: QueryVizProps, nextState: QueryVizState) {
         if(!equal(nextProps, this.props)) {
             return true;
-        } else if(this.state.data === null && !equal(nextState, this.state)) {
+        } else if((nextState.data === null || this.state.data === null) && !equal(nextState, this.state)) {
             return true;
         } else if(nextState.data !== null && this.state.data !== null) {
             return queryDataChanged(nextState.data, this.state.data) || !equal({ ...nextState, data: null }, { ...this.state, data: null });
@@ -117,6 +117,7 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
 
     componentDidUpdate(prevProps: QueryVizProps) {
         if(!equal(this.props.data_indices, prevProps.data_indices)) {
+            this.setState({ data: null });
             this._updateData();
         }
     }

--- a/src/QueryViz.tsx
+++ b/src/QueryViz.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 
-import { queryKey, getDataById, QueryMeta, QueryVizData, queryDataChanged } from './query';
+import { queryKey, getDataById, QueryMeta, QueryVizData, relevantFights, missingFights, queryDataChanged } from './query';
 import { clearQueryIndex, exportViz, deleteViz, hasReportMeta, ReportCode, VizState, Guid, AppState, setVizSpec, } from './store';
 import Vega, { VisualizationSpec, EmbedOptions } from './vega';
 import QueryBuilder from './QueryBuilder';
@@ -187,9 +187,13 @@ class QueryViz extends React.Component<QueryVizProps, QueryVizState> {
 
 function getDataIndices(state: AppState, code: ReportCode | null, query: QueryMeta | null): number[] | null {
     if(code && hasReportMeta(state, code) && query) {
+        if(missingFights(query, code, state).length > 0) {
+            return null; // don't show anything if we are missing data
+        }
+        const relevant_fights = relevantFights(query, code, state);
         const indices = state.reports.getIn([code, 'queries', queryKey(query)]);
         if(indices) {
-            return indices.valueSeq().toArray();
+            return indices.filter((_: any, fid: string) => relevant_fights.includes(parseInt(fid))).valueSeq().toArray();
         }
     }
     return null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ import { Guid as GuidCreator } from 'guid-typescript';
 import { Map, OrderedMap, Set, List, Seq } from 'immutable';
 
 import { load_meta, load_query_data } from './request';
-import { QueryId, QueryMeta, queryKey, queryFormatData, createQueryMeta, shouldUpdate as shouldUpdateQuery, missingFights as queryFightsMissing, isQueryMeta, storeData } from './query';
+import { QueryId, QueryMeta, queryKey, queryFormatData, createQueryMeta, shouldUpdate as shouldUpdateQuery, missingFights as queryFightsMissing, isQueryMeta, storeData, clearDB as clearQueryDB } from './query';
 
 export interface ApiKey extends Newtype<{readonly ApiKey: unique symbol}, string> {}
 
@@ -108,7 +108,7 @@ function emptyReportState(code: ReportCode): ReportState {
     };
 }
 
-const CURRENT_VERSION = 2;
+const CURRENT_VERSION = 3;
 
 const initialState: AppState = {
     version: CURRENT_VERSION,
@@ -649,7 +649,19 @@ const migrations = {
                 };
             })
         };
-    }
+    },
+    3: (state: any) => {
+        clearQueryDB();
+        return {
+            ...state,
+            reports: state.reports.map((report: any) => {
+                return {
+                    ...report,
+                    queries: Map(),
+                };
+            })
+        }
+    },
 };
 
 export default function buildStore() {


### PR DESCRIPTION
This means that if you switch a query from a specific boss to all bosses, it will re-use existing data for any individual bosses you've looked at. Similarly, if you've pulled in all the boss data, then looking at a single boss no longer requires additional queries.

This is a breaking change, so the query data DB is cleared.

Also, fixed an issue where sometimes the visualizations wouldn't reset when you switched reports.